### PR TITLE
Metaevidence URI is now shorter

### DIFF
--- a/src/sagas/arbitrable-address-list.js
+++ b/src/sagas/arbitrable-address-list.js
@@ -184,7 +184,7 @@ export function* fetchArbitrableAddressListData() {
 function* submitBadgeEvidence({
   payload: { evidenceData, file, tokenAddress, badgeContractAddr, evidenceSide }
 }) {
-  const { badgeContracts, archon } = yield call(instantiateEnvObjects)
+  const { badgeContracts } = yield call(instantiateEnvObjects)
   const arbitrableAddressList = badgeContracts[badgeContractAddr]
 
   let fileURI = ''
@@ -238,10 +238,6 @@ function* submitBadgeEvidence({
     fileTypeExtension,
     evidenceSide
   }
-
-  /* eslint-disable unicorn/number-literal-case */
-  const evidenceJSONMultihash = archon.utils.multihashFile(evidenceJSON, 0x1b) // 0x1b is keccak-256
-  /* eslint-enable */
 
   const enc = new TextEncoder()
   const ipfsHashEvidenceObj = yield call(

--- a/src/sagas/arbitrable-address-list.js
+++ b/src/sagas/arbitrable-address-list.js
@@ -251,7 +251,7 @@ function* submitBadgeEvidence({
   )
 
   const ipfsHashEvidence =
-    ipfsHashEvidenceObj[1].hash + "/evidence.json"
+    ipfsHashEvidenceObj[1].hash + ipfsHashEvidenceObj[0].path
 
   yield call(
     arbitrableAddressList.methods.submitEvidence(

--- a/src/sagas/arbitrable-address-list.js
+++ b/src/sagas/arbitrable-address-list.js
@@ -246,7 +246,7 @@ function* submitBadgeEvidence({
   const enc = new TextEncoder()
   const ipfsHashEvidenceObj = yield call(
     ipfsPublish,
-    evidenceJSONMultihash,
+    "evidence.json",
     enc.encode(JSON.stringify(evidenceJSON))
   )
 

--- a/src/sagas/arbitrable-address-list.js
+++ b/src/sagas/arbitrable-address-list.js
@@ -251,7 +251,7 @@ function* submitBadgeEvidence({
   )
 
   const ipfsHashEvidence =
-    ipfsHashEvidenceObj[1].hash + ipfsHashEvidenceObj[0].path
+    ipfsHashEvidenceObj[1].hash + "/evidence.json"
 
   yield call(
     arbitrableAddressList.methods.submitEvidence(

--- a/src/sagas/arbitrable-token-list.js
+++ b/src/sagas/arbitrable-token-list.js
@@ -227,7 +227,7 @@ function* submitTokenEvidence({
   const enc = new TextEncoder()
   const ipfsHashEvidenceObj = yield call(
     ipfsPublish,
-    evidenceJSONMultihash,
+    "evidence.json",
     enc.encode(JSON.stringify(evidenceJSON))
   )
 

--- a/src/sagas/arbitrable-token-list.js
+++ b/src/sagas/arbitrable-token-list.js
@@ -232,7 +232,7 @@ function* submitTokenEvidence({
   )
 
   const ipfsHashEvidence =
-    ipfsHashEvidenceObj[1].hash + ipfsHashEvidenceObj[0].path
+    ipfsHashEvidenceObj[1].hash + "/evidence.json"
 
   yield call(
     arbitrableTokenList.methods.submitEvidence(ID, `/ipfs/${ipfsHashEvidence}`)

--- a/src/sagas/arbitrable-token-list.js
+++ b/src/sagas/arbitrable-token-list.js
@@ -232,7 +232,7 @@ function* submitTokenEvidence({
   )
 
   const ipfsHashEvidence =
-    ipfsHashEvidenceObj[1].hash + "/evidence.json"
+    ipfsHashEvidenceObj[1].hash + ipfsHashEvidenceObj[0].path
 
   yield call(
     arbitrableTokenList.methods.submitEvidence(ID, `/ipfs/${ipfsHashEvidence}`)

--- a/src/sagas/arbitrable-token-list.js
+++ b/src/sagas/arbitrable-token-list.js
@@ -218,11 +218,7 @@ function* submitTokenEvidence({
     evidenceSide
   }
 
-  const { arbitrableTokenList, archon } = yield call(instantiateEnvObjects)
-
-  /* eslint-disable unicorn/number-literal-case */
-  const evidenceJSONMultihash = archon.utils.multihashFile(evidenceJSON, 0x1b) // 0x1b is keccak-256
-  /* eslint-enable */
+  const { arbitrableTokenList } = yield call(instantiateEnvObjects)
 
   const enc = new TextEncoder()
   const ipfsHashEvidenceObj = yield call(

--- a/src/sagas/token.js
+++ b/src/sagas/token.js
@@ -263,7 +263,7 @@ function* requestRegistration({ payload: { token, file, fileData, value } }) {
     const data = yield call(readFile, file.preview)
     const fileMultihash = archon.utils.multihashFile(fileData, 0x1b) // keccak-256
     try {
-      const ipfsFileObj = yield call(ipfsPublish, fileMultihash, data)
+      const ipfsFileObj = yield call(ipfsPublish, "evidence.json", data)
       tokenToSubmit.symbolMultihash = `/ipfs/${ipfsFileObj[1].hash}${
         ipfsFileObj[0].path
       }`
@@ -326,7 +326,7 @@ function* requestStatusChange({ payload: { token, file, fileData, value } }) {
     const data = yield call(readFile, file.preview)
     const fileMultihash = archon.utils.multihashFile(fileData, 0x1b) // keccak-256
     try {
-      const ipfsFileObj = yield call(ipfsPublish, fileMultihash, data)
+      const ipfsFileObj = yield call(ipfsPublish, "evidence.json", data)
       tokenToSubmit.symbolMultihash = `/ipfs/${ipfsFileObj[1].hash}${
         ipfsFileObj[0].path
       }`

--- a/src/sagas/token.js
+++ b/src/sagas/token.js
@@ -249,7 +249,7 @@ export function* fetchToken({ payload: { ID } }) {
  * @returns {object} - The `lessdux` collection mod object for updating the list of tokens.
  */
 function* requestRegistration({ payload: { token, file, fileData, value } }) {
-  const { archon, arbitrableTokenList } = yield call(instantiateEnvObjects)
+  const { arbitrableTokenList } = yield call(instantiateEnvObjects)
 
   const tokenToSubmit = {
     name: token.name,
@@ -261,7 +261,6 @@ function* requestRegistration({ payload: { token, file, fileData, value } }) {
   if (file && fileData) {
     /* eslint-disable unicorn/number-literal-case */
     const data = yield call(readFile, file.preview)
-    const fileMultihash = archon.utils.multihashFile(fileData, 0x1b) // keccak-256
     try {
       const ipfsFileObj = yield call(ipfsPublish, "evidence.json", data)
       tokenToSubmit.symbolMultihash = `/ipfs/${ipfsFileObj[1].hash}${
@@ -312,7 +311,7 @@ function* requestStatusChange({ payload: { token, file, fileData, value } }) {
   if (isInvalid(token.ID) && isInvalid(token.address))
     throw new Error('Missing address on token submit', token)
 
-  const { arbitrableTokenList, archon } = yield call(instantiateEnvObjects)
+  const { arbitrableTokenList } = yield call(instantiateEnvObjects)
 
   const tokenToSubmit = {
     name: token.name,
@@ -324,7 +323,6 @@ function* requestStatusChange({ payload: { token, file, fileData, value } }) {
   if (file && fileData) {
     /* eslint-disable unicorn/number-literal-case */
     const data = yield call(readFile, file.preview)
-    const fileMultihash = archon.utils.multihashFile(fileData, 0x1b) // keccak-256
     try {
       const ipfsFileObj = yield call(ipfsPublish, "evidence.json", data)
       tokenToSubmit.symbolMultihash = `/ipfs/${ipfsFileObj[1].hash}${


### PR DESCRIPTION
This makes _evidence take less space, so calling `submitEvidence` costs less gas. I'm not sure on how this affects ERC-1497.
#67 is related to this.
If multihash is required, a shorter hash that replaces "evidence.json" can also do the trick.
If this is merged, I will make similar changes in gtcr and other affected repos.